### PR TITLE
Fixing kmz export example

### DIFF
--- a/example-cameraandwmsandwcs/build.gradle
+++ b/example-cameraandwmsandwcs/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     implementation (group: 'mil.army.missioncommand', name: 'mil-sym-android-renderer', ext: 'aar') { transitive = true }
 
     implementation ("com.android.support:appcompat-v7:23.2.1")
-    compile project(path: ':example-mapfragmentandview:example-mapfragmentandview-MapTestFragment')
+    implementation project(path: ':example-mapfragmentandview:example-mapfragmentandview-MapTestFragment')
     implementation 'com.android.databinding:library:1.3.1'
     implementation 'com.android.databinding:adapters:1.3.1'
 }

--- a/example-kmz-exportimport/src/main/java/mil/emp3/example_kmz_exportimport/MainActivity.java
+++ b/example-kmz-exportimport/src/main/java/mil/emp3/example_kmz_exportimport/MainActivity.java
@@ -2,6 +2,7 @@ package mil.emp3.example_kmz_exportimport;
 
 import android.Manifest;
 import android.content.pm.PackageManager;
+import android.os.Environment;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.util.Log;
@@ -116,7 +117,15 @@ public class MainActivity extends AppCompatActivity
         }
         //create a temp directory for the exporter
         final File tempDirectory = this.getApplicationContext().getExternalFilesDir(null);
-        tempDirectory.mkdirs();
+//        tempDirectory.mkdirs();
+
+        final String kmzExportedFileName = "My_Kmz_File";
+        //Delete the previously exported kmzFile
+        final File kmzExportedFile = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES), "KMZExport" + File.separator + kmzExportedFileName + ".kmz");
+        if(kmzExportedFile.exists())
+        {
+            kmzExportedFile.delete();
+        }
 
         //Export the overlay as a kmz file
         EmpKMZExporter.exportToKMZ(this.map,
@@ -142,7 +151,7 @@ public class MainActivity extends AppCompatActivity
                                                                            }
                                                                        },
                                    tempDirectory.getAbsolutePath(),
-                                   "My_Kmz_File");
+                                   kmzExportedFileName);
     }
 
     private static final int PERMISSION_REQUEST_CODE = 1;
@@ -155,7 +164,7 @@ public class MainActivity extends AppCompatActivity
             if (checkSelfPermission(permission) == PackageManager.PERMISSION_DENIED)
             {
 
-                Log.d("permission", String.format("permission denied to %s - requesting it"));
+                Log.d("permission", String.format("permission denied to %s - requesting it", permission));
                 final String[] permissions = {permission};
 
                 requestPermissions(permissions, PERMISSION_REQUEST_CODE);

--- a/example-kmz-exportimport/src/main/java/mil/emp3/example_kmz_exportimport/MainActivity.java
+++ b/example-kmz-exportimport/src/main/java/mil/emp3/example_kmz_exportimport/MainActivity.java
@@ -16,12 +16,9 @@ import java.util.HashMap;
 import java.util.UUID;
 import java.util.concurrent.LinkedBlockingQueue;
 
-import mil.emp3.api.Camera;
 import mil.emp3.api.KMLS;
 import mil.emp3.api.Overlay;
-import mil.emp3.api.enums.KMLSEventEnum;
 import mil.emp3.api.exceptions.EMP_Exception;
-import mil.emp3.api.interfaces.ICamera;
 import mil.emp3.api.interfaces.IEmpExportToTypeCallBack;
 import mil.emp3.api.interfaces.IFeature;
 import mil.emp3.api.interfaces.IMap;
@@ -117,7 +114,6 @@ public class MainActivity extends AppCompatActivity
         }
         //create a temp directory for the exporter
         final File tempDirectory = this.getApplicationContext().getExternalFilesDir(null);
-//        tempDirectory.mkdirs();
 
         final String kmzExportedFileName = "My_Kmz_File";
         //Delete the previously exported kmzFile

--- a/example-mapfragmentandview/MapTestFragment/build.gradle
+++ b/example-mapfragmentandview/MapTestFragment/build.gradle
@@ -25,8 +25,8 @@ android {
 }
 
 dependencies {
-    compile     ("com.android.support:appcompat-v7:23.2.1")
-    compile     ("com.android.support:support-v4:23.2.1")
+    implementation     ("com.android.support:appcompat-v7:23.2.1")
+    implementation     ("com.android.support:support-v4:23.2.1")
     testImplementation ("junit:junit:4.12")
-    provided (group: 'mil.army.missioncommand', name: 'emp3-android-sdk', version: "$version_emp3Android", ext: 'jar') { transitive = true }
+    compileOnly (group: 'mil.army.missioncommand', name: 'emp3-android-sdk', version: "$version_emp3Android", ext: 'jar') { transitive = true }
 }

--- a/example-mapfragmentandview/SampleMapFragmentPgm/build.gradle
+++ b/example-mapfragmentandview/SampleMapFragmentPgm/build.gradle
@@ -21,7 +21,7 @@ android {
 }
 
 dependencies {
-    compile project(":example-mapfragmentandview:example-mapfragmentandview-MapTestFragment")
+    implementation project(":example-mapfragmentandview:example-mapfragmentandview-MapTestFragment")
 
     implementation (group: 'mil.army.missioncommand', name: 'emp3-android-sdk-view', version: "$version_emp3Android", ext: 'aar') { transitive = true }
     implementation (group: 'mil.army.missioncommand', name: 'emp3-android-sdk-core', version: "$version_emp3Android", ext: 'aar') { transitive = true }

--- a/example-mapfragmentandview/SampleMapView/build.gradle
+++ b/example-mapfragmentandview/SampleMapView/build.gradle
@@ -21,7 +21,7 @@ android {
 }
 dependencies {
     implementation ("com.android.support:appcompat-v7:23.2.1")
-    compile project(":example-mapfragmentandview:example-mapfragmentandview-MapTestFragment")
+    implementation project(":example-mapfragmentandview:example-mapfragmentandview-MapTestFragment")
 
     implementation (group: 'mil.army.missioncommand', name: 'emp3-android-sdk-view', version: "$version_emp3Android", ext: 'aar') { transitive = true }
     implementation (group: 'mil.army.missioncommand', name: 'emp3-android-sdk-core', version: "$version_emp3Android", ext: 'aar') { transitive = true }

--- a/example-mapfragmentandview/SampleMapViewPgm/build.gradle
+++ b/example-mapfragmentandview/SampleMapViewPgm/build.gradle
@@ -28,7 +28,7 @@ android {
 dependencies {
     implementation ("com.android.support:appcompat-v7:23.2.1")
 
-    compile project (":example-mapfragmentandview:example-mapfragmentandview-MapTestFragment")
+    implementation project (":example-mapfragmentandview:example-mapfragmentandview-MapTestFragment")
 
     implementation (group: 'mil.army.missioncommand', name: 'emp3-android-sdk-view', version: "$version_emp3Android", ext: 'aar') { transitive = true }
     implementation (group: 'mil.army.missioncommand', name: 'emp3-android-sdk-core', version: "$version_emp3Android", ext: 'aar') { transitive = true }


### PR DESCRIPTION
-Instead of overwriting the file exported the new functionality of kmz throws an exception if the file already exists
-fixes gradle warnings of compile vs implmentation